### PR TITLE
Release 3.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "symmetric"
-version = "3.0.0"
+version = "3.1.0"
 description = "A powerful yet lean wrapper over Flask to massively speed up API creations and enable super fast module-to-API transformations."
 license = "MIT"
 authors = ["Daniel Leal <dlleal@uc.cl>"]

--- a/symmetric/cli_utils.py
+++ b/symmetric/cli_utils.py
@@ -37,7 +37,7 @@ def document_openapi(module, filename):
     """
     symmetric_object = get_symmetric_object(module, True)
     docs = symmetric.openapi.utils.get_openapi(
-        symmetric_object.endpoints,
+        symmetric_object,
         f"{symmetric.helpers.humanize(module)} API"
     )
     with open(filename, "w") as docs_file:

--- a/symmetric/cli_utils.py
+++ b/symmetric/cli_utils.py
@@ -9,6 +9,7 @@ import traceback
 import importlib
 
 import symmetric.errors
+import symmetric.openapi.utils
 
 
 def start_server(module, server, port, debug):
@@ -35,7 +36,10 @@ def document_openapi(module, filename):
     Gets the symmetric object and then calls the OpenAPI Specification method.
     """
     symmetric_object = get_symmetric_object(module, True)
-    docs = symmetric_object.openapi_documentation(module)
+    docs = symmetric.openapi.utils.get_openapi(
+        symmetric_object.endpoints,
+        f"{symmetric.helpers.humanize(module)} API"
+    )
     with open(filename, "w") as docs_file:
         json.dump(docs, docs_file, indent=2)
 

--- a/symmetric/constants.py
+++ b/symmetric/constants.py
@@ -6,6 +6,10 @@ A module for every constant of symmetric.
 # Logs
 LOG_FILE_NAME = "symmetric.log"
 
+# Docs
+OPENAPI_ROUTE = "/openapi.json"
+DOCUMENTATION_ROUTE = "/docs"
+
 # API token authentication
 API_CLIENT_TOKEN_NAME = "symmetric_api_key"
 API_SERVER_TOKEN_NAME = "SYMMETRIC_API_KEY"

--- a/symmetric/core.py
+++ b/symmetric/core.py
@@ -56,12 +56,17 @@ class Symmetric:
         """
         if not self.__openapi_schema:
             self.__openapi_schema = symmetric.openapi.utils.get_openapi(
-                self.__endpoints,
+                self,
                 symmetric.helpers.humanize(
                     symmetric.helpers.get_module_name(self)
                 ) + " API"
             )
         return self.__openapi_schema
+
+    @property
+    def client_token_name(self):
+        """Return the client token name."""
+        return self.__client_token_name
 
     def setup(self):
         """Sets up the API."""

--- a/symmetric/core.py
+++ b/symmetric/core.py
@@ -188,7 +188,7 @@ class Symmetric:
         docs += "API Documentation\n\n"
         docs += ("Endpoints that require an authentication token should "
                  f"send it in a key named `{self.__client_token_name}` "
-                 "inside the request body.\n\n")
+                 "inside the request headers.\n\n")
         raw_docs = [
             x.generate_markdown_documentation() for x in self.__endpoints]
         docs += "\n".join(raw_docs)

--- a/symmetric/core.py
+++ b/symmetric/core.py
@@ -39,6 +39,11 @@ class Symmetric:
         self.__server_token_name = symmetric.constants.API_SERVER_TOKEN_NAME
         self.__client_token_name = symmetric.constants.API_CLIENT_TOKEN_NAME
 
+    @property
+    def endpoints(self):
+        """Returns a list with the endpoints."""
+        return self.__endpoints
+
     def __call__(self, *args, **kwargs):
         """
         Enable WSGI servers to start with CLI utilities

--- a/symmetric/core.py
+++ b/symmetric/core.py
@@ -143,12 +143,13 @@ class Symmetric:
 
                     # Get the body
                     body = flask.request.get_json()
+                    request_headers = flask.request.headers
                     if not body:
                         body = {}
 
                     # Check for token authentication
                     symmetric.helpers.authenticate(
-                        body, auth_token, self.__client_token_name,
+                        request_headers, auth_token, self.__client_token_name,
                         self.__server_token_name)
 
                     # Filter method parameters

--- a/symmetric/endpoints.py
+++ b/symmetric/endpoints.py
@@ -4,8 +4,6 @@ This module contains the endpoints classes.
 
 import inspect
 
-import symmetric.helpers
-
 
 class Endpoint:
 
@@ -31,139 +29,34 @@ class Endpoint:
         """Returns the route of the endpoint."""
         return self.__route
 
-    # COMMON DOCUMENTATION METHODS
+    @property
+    def methods(self):
+        """Returns the HTTP methods of the endpoint."""
+        return self.__methods
 
-    def __get_docstring(self):
-        """Gets the docstring of the function."""
+    @property
+    def response_code(self):
+        """Returns the response code of the endpoint."""
+        return self.__response_code
+
+    @property
+    def function(self):
+        """Returns the function of the endpoint."""
+        return self.__function
+
+    @property
+    def has_token(self):
+        """
+        Returns the a boolean representing whether or not of the endpoint
+        requires an authentication token.
+        """
+        return self.__has_token
+
+    @property
+    def docstring(self):
+        """Returns the docstring of the function."""
         docstring = inspect.getdoc(self.__function)
         return docstring if docstring else "No description provided."
-
-    # JSON SCHEMA DOCUMENTATION METHODS
-
-    def openapi_documentation(self):
-        """Generate the OpenAPI documentation for the endpoint."""
-        request_body = self.__json_schema_request_body()
-        response_codes = self.__response_codes_openapi()
-        docstring = self.__get_docstring()
-        path_doc = {}
-        for http_method in map(lambda x: x.lower(), self.__methods):
-            path_doc[http_method] = {
-                "description": docstring,
-                "responses": response_codes
-            }
-            has_props = bool(request_body["properties"])
-            has_body = has_props or bool(request_body["additionalProperties"])
-            if has_body:
-                path_doc[http_method]["requestBody"] = {
-                    "required": has_props,
-                    "content": {
-                        "application/json": {
-                            "schema": request_body
-                        }
-                    }
-                }
-        return {
-            self.__route: path_doc
-        }
-
-    def __json_schema_request_body(self):
-        """Assembles the JSON schema for the request body."""
-        any_type = [
-            {
-                "type": "string"
-            },
-            {
-                "type": "number"
-            },
-            {
-                "type": "integer"
-            },
-            {
-                "type": "boolean"
-            },
-            {
-                "type": "array"
-            },
-            {
-                "type": "object"
-            },
-        ]
-        params = inspect.getfullargspec(self.__function)
-        schema = {}
-        if params.args:
-            parameters_amount = len(params.args)
-            if params.defaults:
-                defaults_amount = len(params.defaults)
-                no_defaults = parameters_amount - defaults_amount
-                for ii in range(no_defaults):
-                    if params.args[ii] not in params.annotations:
-                        var_label = "oneOf"
-                        var_type = any_type
-                    else:
-                        var_label = "type"
-                        var_type = symmetric.helpers.type_to_string(
-                            params.annotations[params.args[ii]])
-                    schema[params.args[ii]] = {
-                        var_label: var_type
-                    }
-                for jj in range(defaults_amount):
-                    if params.args[no_defaults + jj] not in params.annotations:
-                        var_label = "oneOf"
-                        var_type = any_type
-                    else:
-                        var_label = "type"
-                        var_type = symmetric.helpers.type_to_string(
-                            params.annotations[params.args[no_defaults + jj]])
-                    schema[params.args[no_defaults + jj]] = {
-                        var_label: var_type,
-                        "default": params.defaults[jj]
-                    }
-            else:
-                for ii in range(parameters_amount):
-                    if params.args[ii] not in params.annotations:
-                        var_label = "oneOf"
-                        var_type = any_type
-                    else:
-                        var_label = "type"
-                        var_type = symmetric.helpers.type_to_string(
-                            params.annotations[params.args[ii]])
-                    schema[params.args[ii]] = {
-                        var_label: var_type
-                    }
-        return {
-            "type": "object",
-            "properties": schema,
-            "additionalProperties": params.varkw is not None
-        }
-
-    def __response_codes_openapi(self):
-        """Gets the error codes for the OpenAPI Schema."""
-        params = inspect.getfullargspec(self.__function)
-        responses = {
-            f"{self.__response_code}": {
-                "description": "Successful operation"
-            },
-            "500": {
-                "description": "Unexpected internal error (API method "
-                               "failed, probably due to a missuse of the "
-                               "underlying function)."
-            }
-        }
-        if self.__has_token:
-            responses["401"] = {
-                "description": "Invalid or non-existent authentication "
-                               "credentials."
-            }
-        if "return" in params.annotations:
-            responses[f"{self.__response_code}"]["content"] = {
-                "application/json": {
-                    "schema": {
-                        "type": symmetric.helpers.type_to_string(
-                            params.annotations["return"])
-                    }
-                }
-            }
-        return responses
 
     # MARKDOWN DOCUMENTATION METHODS
 
@@ -171,7 +64,7 @@ class Endpoint:
         """Generates the documentation of the function."""
         docstring = f"## `{self.__route}`\n\n"
         docstring += f"### Description\n\n"
-        docstring += f"{self.__get_docstring()}\n\n"
+        docstring += f"{self.docstring}\n\n"
         docstring += f"### Metadata\n\n"
         docstring += f"`HTTP` methods accepted: "
         docstring += f"{', '.join([f'`{x}`' for x in self.__methods])}\n\n"

--- a/symmetric/helpers.py
+++ b/symmetric/helpers.py
@@ -18,6 +18,17 @@ def verb(dirty):
     return dirty.strip().upper()
 
 
+def get_module_name(symmetric_object):
+    """
+    Given a symmetric object, returns the name of the module where the
+    first endpoint was defined. If such endpoint does not exist, return
+    a generic module name.
+    """
+    if not symmetric_object.endpoints:
+        return "symmetric"
+    return symmetric_object.endpoints[0].function.__module__.split(".")[0]
+
+
 def type_to_string(type_obj):
     """Given a python type, return its JSON schema string counterpart."""
     type_str = type_obj.__name__

--- a/symmetric/helpers.py
+++ b/symmetric/helpers.py
@@ -67,22 +67,22 @@ def parse_route(route):
         raise symmetric.errors.IncorrectRouteFormatError(message)
 
 
-def authenticate(body, auth_token, client_token_name, server_token_name):
+def authenticate(headers, auth_token, client_token_name, server_token_name):
     """
-    Raises an exception if the body does not include the client token
+    Raises an exception if the headers do not include the client token
     or if it is different to the server token.
     """
     if not auth_token:
         # No auth is required
         return
     # Auth is required from now on
-    if client_token_name not in body:
-        # The body does not include the desired token
+    if client_token_name not in headers:
+        # The headers do not include the desired token
         error = "The request does not include an authentication token."
         raise symmetric.errors.AuthenticationRequiredError(error)
-    # If the token in the body equals the one in the env, return True
+    # If the token in the headers equals the one in the env, return True
     token = os.getenv(server_token_name, symmetric.constants.API_DEFAULT_TOKEN)
-    if body[client_token_name] != token:
+    if headers[client_token_name] != token:
         error = "Incorrect authentication token."
         raise symmetric.errors.AuthenticationRequiredError(error)
 

--- a/symmetric/openapi/constants.py
+++ b/symmetric/openapi/constants.py
@@ -1,0 +1,25 @@
+"""
+Module to hold the openapi documentation constants.
+"""
+
+
+ANY_TYPE = [
+    {
+        "type": "string"
+    },
+    {
+        "type": "number"
+    },
+    {
+        "type": "integer"
+    },
+    {
+        "type": "boolean"
+    },
+    {
+        "type": "array"
+    },
+    {
+        "type": "object"
+    },
+]

--- a/symmetric/openapi/docs.py
+++ b/symmetric/openapi/docs.py
@@ -1,0 +1,41 @@
+"""
+A module for documentation HTML methods.
+"""
+
+import flask
+
+import symmetric.constants
+
+
+def get_redoc_html(title):
+    redoc_script = ("https://cdn.jsdelivr.net/npm/redoc/bundles/"
+                    "redoc.standalone.js")
+    google_fonts = ("https://fonts.googleapis.com/css?family=Montserrat:"
+                    "300,400,700|Roboto:300,400,700")
+    html = f"""
+    <!DOCTYPE html>
+    <html>
+        <head>
+            <title>{title}</title>
+            <!-- needed for adaptive design -->
+            <meta charset="utf-8"/>
+            <meta
+                name="viewport"
+                content="width=device-width, initial-scale=1"
+            >
+            <link href="{google_fonts}" rel="stylesheet">
+            <style>
+            body {{
+                margin: 0;
+                padding: 0;
+            }}
+            </style>
+        </head>
+            <body>
+            <redoc spec-url="{symmetric.constants.OPENAPI_ROUTE}">
+            </redoc>
+            <script src="{redoc_script}"></script>
+        </body>
+    </html>
+    """
+    return flask.render_template_string(html)

--- a/symmetric/openapi/helpers.py
+++ b/symmetric/openapi/helpers.py
@@ -1,0 +1,16 @@
+"""
+A module for every helper of the OpenAPI documentation generator.
+"""
+
+import symmetric.constants
+
+
+def is_not_docs(route):
+    """Checks if a route is not a documentation-related route."""
+    # Check that the route is not the schema route
+    not_schema = route != symmetric.constants.OPENAPI_ROUTE
+    # Check that the route is not the interactive documentation route
+    not_documentation = route != symmetric.constants.DOCUMENTATION_ROUTE
+
+    # Return if the route is neither of the documentation routes
+    return not_schema and not_documentation

--- a/symmetric/openapi/utils.py
+++ b/symmetric/openapi/utils.py
@@ -6,6 +6,7 @@ import inspect
 import functools
 
 import symmetric.openapi.constants
+import symmetric.openapi.helpers
 
 
 def get_openapi_endpoint(endpoint):
@@ -116,7 +117,8 @@ def get_openapi(endpoints, title, version="0.0.1", openapi_version="3.0.3"):
         },
         "paths": functools.reduce(
             lambda x, y: {**x, **y},
-            [get_openapi_endpoint(endpoint) for endpoint in endpoints],
+            [get_openapi_endpoint(endpoint) for endpoint in endpoints
+                if symmetric.openapi.helpers.is_not_docs(endpoint.route)],
             {}
         )
     }

--- a/symmetric/openapi/utils.py
+++ b/symmetric/openapi/utils.py
@@ -1,0 +1,122 @@
+"""
+Module to hold the openapi documentation creation utilities.
+"""
+
+import inspect
+import functools
+
+import symmetric.openapi.constants
+
+
+def get_openapi_endpoint(endpoint):
+    """Generate the OpenAPI documentation for :endpoint."""
+    request_body = get_openapi_endpoint_body(endpoint)
+    response_codes = get_openapi_endpoint_responses(endpoint)
+    path_doc = {}
+    for http_method in map(lambda x: x.lower(), endpoint.methods):
+        path_doc[http_method] = {
+            "description": endpoint.docstring,
+            "responses": response_codes
+        }
+        has_props = bool(request_body["properties"])
+        has_body = has_props or bool(request_body["additionalProperties"])
+        if has_body:
+            path_doc[http_method]["requestBody"] = {
+                "required": has_props,
+                "content": {
+                    "application/json": {
+                        "schema": request_body
+                    }
+                }
+            }
+    return {
+        endpoint.route: path_doc
+    }
+
+
+def get_openapi_endpoint_body(endpoint):
+    """Assembles the JSON schema for the endpoint body."""
+    params = inspect.getfullargspec(endpoint.function)
+    schema = {}
+    if params.args:
+        parameters_amount = len(params.args)
+        defaults_amount = 0 if not params.defaults else len(params.defaults)
+        defaults_amount = len(params.defaults)
+        no_defaults = parameters_amount - defaults_amount
+        for ii in range(no_defaults):
+            if params.args[ii] not in params.annotations:
+                var_label = "oneOf"
+                var_type = symmetric.openapi.constants.ANY_TYPE
+            else:
+                var_label = "type"
+                var_type = symmetric.helpers.type_to_string(
+                    params.annotations[params.args[ii]])
+            schema[params.args[ii]] = {
+                var_label: var_type
+            }
+        for jj in range(defaults_amount):
+            if params.args[no_defaults + jj] not in params.annotations:
+                var_label = "oneOf"
+                var_type = symmetric.openapi.constants.ANY_TYPE
+            else:
+                var_label = "type"
+                var_type = symmetric.helpers.type_to_string(
+                    params.annotations[params.args[no_defaults + jj]])
+            schema[params.args[no_defaults + jj]] = {
+                var_label: var_type,
+                "default": params.defaults[jj]
+            }
+    return {
+        "type": "object",
+        "properties": schema,
+        "additionalProperties": params.varkw is not None
+    }
+
+
+def get_openapi_endpoint_responses(endpoint):
+    """Gets the OpenAPI Schema error codes for the endpoint."""
+    params = inspect.getfullargspec(endpoint.function)
+    responses = {
+        f"{endpoint.response_code}": {
+            "description": "Successful operation"
+        },
+        "500": {
+            "description": "Unexpected internal error (API method "
+                           "failed, probably due to a missuse of the "
+                           "underlying function)."
+        }
+    }
+    if endpoint.has_token:
+        responses["401"] = {
+            "description": "Invalid or non-existent authentication "
+                           "credentials."
+        }
+    if "return" in params.annotations:
+        responses[f"{endpoint.response_code}"]["content"] = {
+            "application/json": {
+                "schema": {
+                    "type": symmetric.helpers.type_to_string(
+                        params.annotations["return"])
+                }
+            }
+        }
+    return responses
+
+
+def get_openapi(endpoints, title, version="0.0.1", openapi_version="3.0.3"):
+    """
+    Gets the OpenAPI spec of every endpoint and assembles it into a
+    JSON formatted object.
+    """
+    return {
+        "openapi": openapi_version,
+        "info": {
+            "title": title,
+            "version": version
+        },
+        "paths": functools.reduce(
+            lambda x, y: {**x, **y},
+            [get_openapi_endpoint(endpoint) for endpoint in endpoints],
+            {}
+        )
+    }

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -61,7 +61,7 @@ class AuthenticationTestCase(unittest.TestCase):
     def test_no_token_required(self):
         """Tests that an error isn't raised when there is no token required."""
         symmetric.helpers.authenticate(
-            body={},
+            headers={},
             auth_token=False,
             client_token_name=symmetric.constants.API_CLIENT_TOKEN_NAME,
             server_token_name=symmetric.constants.API_SERVER_TOKEN_NAME
@@ -70,7 +70,7 @@ class AuthenticationTestCase(unittest.TestCase):
     def test_correct_token(self):
         """Tests that an error isn't raised when the correct token is given."""
         symmetric.helpers.authenticate(
-            body={
+            headers={
                 self.client_token_name: self.token
             },
             auth_token=True,
@@ -82,7 +82,7 @@ class AuthenticationTestCase(unittest.TestCase):
         """Tests that an error is raised when the token is not given."""
         with self.assertRaises(symmetric.errors.AuthenticationRequiredError):
             symmetric.helpers.authenticate(
-                body={
+                headers={
                     self.client_token_name: self.incorrect_token
                 },
                 auth_token=True,
@@ -94,7 +94,7 @@ class AuthenticationTestCase(unittest.TestCase):
         """Tests that an error is raised when an incorrect token is given."""
         with self.assertRaises(symmetric.errors.AuthenticationRequiredError):
             symmetric.helpers.authenticate(
-                body={},
+                headers={},
                 auth_token=True,
                 client_token_name=symmetric.constants.API_CLIENT_TOKEN_NAME,
                 server_token_name=symmetric.constants.API_SERVER_TOKEN_NAME


### PR DESCRIPTION
# Version 3.1.0 :tada:

## Description

This merge updates `symmetric` to version 3.1.0 **officially**.

## Changes:

- API token is now received inside the request header instead of the request body.
- The auto-generated OpenAPI compliant documentation now includes the API token requirement.
- There is now a `/docs` endpoint to enter through the browser and access auto-generated interactive [ReDoc](https://github.com/Redocly/redoc) documentation.
- Cleaner code design.

## Requirements

None.